### PR TITLE
Added Dockerfile for managing mcp server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+FROM node:22.12-alpine AS builder
+
+COPY src /src
+COPY tsconfig.json /tsconfig.json
+COPY package.json /package.json
+COPY package-lock.json /package-lock.json
+
+WORKDIR /src
+
+RUN --mount=type=cache,target=/root/.npm npm install
+
+RUN --mount=type=cache,target=/root/.npm-production npm ci --ignore-scripts --omit-dev
+
+RUN --mount=type=cache,target=/root/.npm-production npm run build
+
+
+FROM node:22-alpine AS release
+
+COPY --from=builder /build /app/dist
+COPY --from=builder /package.json /app/package.json
+COPY --from=builder /package-lock.json /app/package-lock.json
+
+ENV NODE_ENV=production
+
+WORKDIR /app
+
+RUN npm ci --ignore-scripts --omit-dev
+
+ENTRYPOINT ["node", "dist/index.js"]


### PR DESCRIPTION
Docker provides a more convenient way to manage the mcp server environment, ensuring consistency across different development and deployment scenarios.
I'm not deeply familiar with Node.js environments, so there might be room for optimization in the Dockerfile configuration. However, local testing shows that the current implementation works as expected.