### PR TITLE
build: add .roam directory to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN --mount=type=cache,target=/root/.npm npm install
 COPY src /app/src
 COPY tsconfig.json /app/tsconfig.json
 COPY Roam_Markdown_Cheatsheet.md /app/Roam_Markdown_Cheatsheet.md
+COPY .roam/ /app/.roam
 
 # Build the TypeScript project
 RUN npm run build


### PR DESCRIPTION
fixed docker build error: 

```
 > [builder 10/10] RUN npm run build:
0.310
0.310 > roam-research-mcp@0.36.3 build
0.310 > echo "Using custom instructions: .roam/${CUSTOM_INSTRUCTIONS_PREFIX}custom-instructions.md" && tsc && cat Roam_Markdown_Cheatsheet.md .roam/${CUSTOM_INSTRUCTIONS_PREFIX}custom-instructions.md > build/Roam_Markdown_Cheatsheet.md && chmod 755 build/index.js
0.310
0.312 Using custom instructions: .roam/custom-instructions.md
1.254 cat: can't open '.roam/custom-instructions.md': No such file or directory
```