### PR TITLE
fix: correct cheatsheet path for npx/installed environments

### DIFF
--- a/src/tools/tool-handlers.ts
+++ b/src/tools/tool-handlers.ts
@@ -177,7 +177,7 @@ export class ToolHandlers {
 
     const __filename = fileURLToPath(import.meta.url);
     const __dirname = path.dirname(__filename);
-    const cheatsheetPath = path.join(__dirname, '../../Roam_Markdown_Cheatsheet.md');
+    const cheatsheetPath = path.join(__dirname, '../Roam_Markdown_Cheatsheet.md');
 
     try {
       let cheatsheetContent = await fs.promises.readFile(cheatsheetPath, 'utf-8');


### PR DESCRIPTION
## Problem

`roam_markdown_cheatsheet` fails with `ENOENT` when the server is installed via `npx` or `npm install -g`:

```
MCP error -32603: Failed to read cheatsheet: Error: ENOENT: no such file or directory,
  open '/.../node_modules/roam-research-mcp/Roam_Markdown_Cheatsheet.md'
```

## Root Cause

The build script in `package.json` concatenates the source cheatsheet with custom instructions and outputs the result to `build/Roam_Markdown_Cheatsheet.md`:

```sh
cat Roam_Markdown_Cheatsheet.md .roam/...custom-instructions.md > build/Roam_Markdown_Cheatsheet.md
```

But `tool-handlers.ts` resolves the path relative to `build/tools/` using `../../Roam_Markdown_Cheatsheet.md`, which points to the **package root** — not the `build/` directory where the merged file actually lives.

This works in development (the source file exists at the root), but fails in production/npx installs where only the `build/` directory contents are available.

## Fix

Change the relative path from `../../` to `../` so it correctly resolves from `build/tools/tool-handlers.js` to `build/Roam_Markdown_Cheatsheet.md`:

```diff
- const cheatsheetPath = path.join(__dirname, '../../Roam_Markdown_Cheatsheet.md');
+ const cheatsheetPath = path.join(__dirname, '../Roam_Markdown_Cheatsheet.md');
```

## Test Plan

- [x] Verified `tsc` compiles cleanly
- [x] Confirmed `build/tools/tool-handlers.js` contains the corrected path
- [x] Confirmed `build/Roam_Markdown_Cheatsheet.md` exists after build
- [x] Tested in npx environment — `roam_markdown_cheatsheet` tool call returns cheatsheet content successfully