### PR TITLE
fix(server): bind stdio-mode companion HTTP transport to the loopback host

### DIFF
--- a/src/server/roam-server.ts
+++ b/src/server/roam-server.ts
@@ -655,7 +655,10 @@ export class RoamServer {
         });
       } else {
         const availableHttpPort = await findAvailablePort(desiredPort);
-        httpServer.listen(availableHttpPort, () => {
+        // Bind the companion HTTP transport to HTTP_STREAM_HOST (loopback by
+        // default) — listening without a host binds every interface, exposing
+        // the graph token-free on the LAN.
+        httpServer.listen(availableHttpPort, HTTP_STREAM_HOST, () => {
 
         });
       }

--- a/src/server/roam-server.ts
+++ b/src/server/roam-server.ts
@@ -654,7 +654,7 @@ export class RoamServer {
           );
         });
       } else {
-        const availableHttpPort = await findAvailablePort(desiredPort);
+        const availableHttpPort = await findAvailablePort(desiredPort, 2, HTTP_STREAM_HOST);
         // Bind the companion HTTP transport to HTTP_STREAM_HOST (loopback by
         // default) — listening without a host binds every interface, exposing
         // the graph token-free on the LAN.

--- a/src/utils/net.ts
+++ b/src/utils/net.ts
@@ -40,11 +40,15 @@ export function isPortInUse(port: number, host?: string): Promise<boolean> {
  * Finds an available port, starting from a given port and incrementing by a specified amount.
  * @param startPort The port to start checking from.
  * @param incrementBy The amount to increment the port by if it's in use. Defaults to 2.
+ * @param host Optional host to probe. Pass the host you intend to bind — probing
+ *   the wildcard while binding a specific host misses conflicts (an IPv6-wildcard
+ *   probe succeeds alongside an existing 127.0.0.1 listener), so concurrent
+ *   instances would all pick the same port and crash with EADDRINUSE.
  * @returns A promise that resolves to an available port number.
  */
-export async function findAvailablePort(startPort: number, incrementBy = 2): Promise<number> {
+export async function findAvailablePort(startPort: number, incrementBy = 2, host?: string): Promise<number> {
   let port = startPort;
-  while (await isPortInUse(port)) {
+  while (await isPortInUse(port, host)) {
     port += incrementBy;
   }
   return port;


### PR DESCRIPTION
## Problem

In stdio mode (the default when spawned by Claude Desktop or CLI MCP clients), the companion HTTP Stream transport is opened via the auto-port fallback path, which calls `httpServer.listen(availableHttpPort, ...)` with **no host argument** — binding every interface.

Each spawned instance therefore exposes an unauthenticated HTTP MCP endpoint for its graph on the LAN (`HTTP_AUTH_TOKEN` is typically unset in stdio mode, per the docs loopback is considered safe). With several graphs configured, one machine ends up with a wildcard listener per instance (I observed nine, ports 8088–8106) — anyone on the network can read the graphs and write non-protected ones without the Roam API token.

`--server` mode is unaffected: it already binds `HTTP_STREAM_HOST` (default `127.0.0.1`).

## Fix

Pass `HTTP_STREAM_HOST` in the stdio fallback path too, so both paths honor the documented loopback default. One-line change in `src/server/roam-server.ts`, plus a comment.

Verified locally: after the patch, the companion transport binds `127.0.0.1:<port>` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)