### PR TITLE
fix(server): return 404 for unknown session IDs instead of 400

### DIFF
--- a/src/server/roam-server.ts
+++ b/src/server/roam-server.ts
@@ -604,6 +604,24 @@ export class RoamServer {
             return;
           }
 
+          // A request that carries a session ID we don't know (the daemon
+          // restarted, or the session was terminated) is a dead session. Per
+          // the MCP streamable-HTTP spec the server MUST respond 404 so the
+          // client starts a new session with a fresh InitializeRequest.
+          // Falling through to a new transport instead makes the SDK answer
+          // HTTP 400 "Server not initialized", which clients do not treat as
+          // a re-initialize signal — they keep retrying the dead session and
+          // every tool call times out with no useful error.
+          if (sessionId) {
+            res.writeHead(404, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({
+              jsonrpc: '2.0',
+              error: { code: -32001, message: 'Session not found' },
+              id: null,
+            }));
+            return;
+          }
+
           // Create new transport and server for new sessions
           const httpMcpServer = this.createMcpServer('-http');
           const httpStreamTransport = new StreamableHTTPServerTransport({

--- a/src/server/session-404.test.ts
+++ b/src/server/session-404.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { spawn, type ChildProcess } from 'node:child_process';
+
+/**
+ * Integration test for unknown-session handling, run against the built server
+ * (`npm run build` first). Spawned with fake Roam credentials — initialize and
+ * tools/list never touch the Roam backend.
+ */
+
+const PORT = 8478;
+const URL_MCP = `http://127.0.0.1:${PORT}/mcp`;
+
+let child: ChildProcess;
+
+beforeAll(async () => {
+  child = spawn('node', ['build/index.js', '--server'], {
+    env: {
+      ...process.env,
+      ROAM_API_TOKEN: 'fake-token-for-tests',
+      ROAM_GRAPH_NAME: 'fake-graph',
+      HTTP_STREAM_PORT: String(PORT),
+    },
+    stdio: ['ignore', 'ignore', 'pipe'],
+  });
+  await new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error('server did not start in 10s')), 10000);
+    child.stderr!.on('data', (chunk: Buffer) => {
+      if (chunk.toString().includes('listening')) {
+        clearTimeout(timer);
+        resolve();
+      }
+    });
+    child.on('exit', (code) => {
+      clearTimeout(timer);
+      reject(new Error(`server exited early with code ${code}`));
+    });
+  });
+}, 15000);
+
+afterAll(() => {
+  if (child.exitCode === null && child.signalCode === null) {
+    return new Promise<void>((resolve) => {
+      child.once('exit', () => resolve());
+      child.kill('SIGTERM');
+    });
+  }
+});
+
+let rpcId = 1;
+
+async function post(body: unknown, sessionId?: string) {
+  const headers: Record<string, string> = {
+    'content-type': 'application/json',
+    accept: 'application/json, text/event-stream',
+  };
+  if (sessionId) headers['mcp-session-id'] = sessionId;
+  const res = await fetch(URL_MCP, {
+    method: 'POST',
+    headers,
+    body: JSON.stringify(body),
+    signal: AbortSignal.timeout(10000),
+  });
+  let payload: unknown = null;
+  const ctype = res.headers.get('content-type') || '';
+  if (res.status !== 202) {
+    const text = await res.text();
+    const data = ctype.includes('text/event-stream')
+      ? text.split('\n').filter((l) => l.startsWith('data:')).map((l) => l.slice(5).trim()).join('')
+      : text;
+    try { payload = JSON.parse(data); } catch { payload = data; }
+  }
+  return { status: res.status, sessionId: res.headers.get('mcp-session-id'), payload };
+}
+
+describe('unknown session IDs', () => {
+  it('routes a live session normally', async () => {
+    const init = await post({
+      jsonrpc: '2.0',
+      id: rpcId++,
+      method: 'initialize',
+      params: {
+        protocolVersion: '2025-03-26',
+        capabilities: {},
+        clientInfo: { name: 'session-404-test', version: '1.0.0' },
+      },
+    });
+    expect(init.status).toBe(200);
+    expect(init.sessionId).toBeTruthy();
+    await post({ jsonrpc: '2.0', method: 'notifications/initialized' }, init.sessionId!);
+
+    const res = await post({ jsonrpc: '2.0', id: rpcId++, method: 'tools/list' }, init.sessionId!);
+    expect(res.status).toBe(200);
+    expect((res.payload as { result: { tools: unknown[] } }).result.tools.length).toBeGreaterThan(0);
+  });
+
+  it('answers an unknown session ID with an immediate 404 JSON-RPC error', async () => {
+    const started = Date.now();
+    const res = await post(
+      { jsonrpc: '2.0', id: rpcId++, method: 'tools/list' },
+      'deadbeefdeadbeefdeadbeef'
+    );
+    expect(Date.now() - started).toBeLessThan(2000);
+    expect(res.status).toBe(404);
+    const payload = res.payload as { jsonrpc: string; error: { code: number; message: string } };
+    expect(payload.jsonrpc).toBe('2.0');
+    expect(payload.error.code).toBe(-32001);
+    expect(payload.error.message).toMatch(/session not found/i);
+  });
+});


### PR DESCRIPTION
### Problem

When the HTTP server receives a request carrying an `Mcp-Session-Id` it does
not recognize (typically because the server restarted and the in-memory
session map is empty, while the client still holds its old session ID), the
handler falls through to creating a brand-new `StreamableHTTPServerTransport`
and hands it the request. That transport was never initialized, so the SDK
responds **HTTP 400 "Bad Request: Server not initialized"**.

Per the MCP streamable-HTTP transport spec, the server **MUST respond 404**
to a request with a terminated/unknown session, and on 404 the client **MUST
start a new session** with a fresh `InitializeRequest`:

> The server MAY terminate the session at any time, after which it MUST
> respond to requests containing that session ID with HTTP 404 Not Found.
> When a client receives HTTP 404 in response to a request containing an
> `Mcp-Session-Id`, it MUST start a new session by sending a new
> `InitializeRequest` without a session ID attached.
> — MCP spec, Transports → Streamable HTTP → Session Management
> (2025-03-26 and later revisions)

Clients do not treat 400 as a re-initialize signal. In practice this means:
run this server as a long-lived shared HTTP daemon, restart it for any reason,
and every connected client (e.g. Claude Desktop via `mcp-remote` or an `http`
transport entry) wedges permanently on its dead session — each tool call fails
with an opaque multi-minute timeout ("No result received") and the client
never recovers without an app restart. The daemon looks perfectly healthy the
whole time (`/health` ok, zero errors in the log), which makes this miserable
to diagnose from the outside.

### Fix

In the HTTP request handler: if the request carries a session ID that is not
in `activeSessions`, respond immediately with 404 and a JSON-RPC error body,
instead of falling through to a fresh transport. Requests without a session ID
(i.e. new `initialize` handshakes) are unaffected.

With this change a client that held a stale session gets the spec-mandated
signal, re-initializes on its own, and the next tool call succeeds.

### Tests

`src/server/session-404.test.ts` (vitest, spawns the built server with fake
credentials — no Roam network access):

- live session: `initialize` → `tools/list` still routes normally
- unknown session ID: immediate HTTP 404, JSON-RPC error body
  (`code -32001, "Session not found"`), answered in milliseconds rather than
  hanging

`npm test` passes.

### Notes

- Deliberately minimal: no behavior change for any request that does not
  carry an unknown session ID.
- The DELETE handler already answered 404 for unknown sessions; this makes
  POST/GET consistent with it and with the spec.
- Verified against a live Claude Desktop + launchd daemon setup where
  restarts previously wedged the client until the client app was restarted;
  with this fix the client re-initializes cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
